### PR TITLE
Write a documentation comment 부분 수정

### DIFF
--- a/api-design-guidelines/index.md
+++ b/api-design-guidelines/index.md
@@ -56,8 +56,8 @@ without too much boilerplate.  We use checkboxes instead of
   부수적인 효과입니다.
   {:#clarity-over-brevity}
 
-* 모든 선언문에 **주석을 작성하세요.**
-  API 를 설명하는 주석 문서를 작성하면서 얻은 통찰력은 API 설계에 지대한 영향을 미칠 수 있습니다.
+* 모든 선언문에 **문서화용 주석(documentation comments)을 작성하세요.**
+  API 문서를 작성하면서 얻은 통찰력은 API 설계에 지대한 영향을 미칠 수 있습니다.
   다음으로 미루지 말고 꼭 주석을 달아주세요.
   {:#write-doc-comment}
 


### PR DESCRIPTION
원문에서 언급한 documentation comment를 주석으로 번역하면 오해가 생길수 있을것 같습니다.
Xcode에서 지원하는 문서화를 위한 특수 주석이라 구분이 필요해 보입니다.